### PR TITLE
add ISMRMRD_LIB_DIR to link directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR} ${LIBXSLT_INCLUD
 find_package(ISMRMRD REQUIRED)
 find_package(HDF5 1.8 REQUIRED COMPONENTS C)
 INCLUDE_DIRECTORIES( ${ISMRMRD_INCLUDE_DIR} ${HDF5_C_INCLUDE_DIR})
+link_directories( ${ISMRMRD_LIB_DIR} )
 
 add_executable(philips_to_ismrmrd 
                main.cpp


### PR DESCRIPTION
I had installed ISMRMRD via a [conda](https://github.com/conda/conda) recipe so that `libismrmrd` ends up under ~/anaconda/lib.  When I next tried to build a recipe for `philips_to_ismrmrd`, the library was not found.  This is a small fix for that (the same fix proposed here is already present within the CMakeLists.txt for `siemens_to_ismrmrd`).

Also, related to my recent request on `ismrmrd-python`, can you tag a version of this repository based on current master (preferably after merging this fix) so that there is a tagged version that is compatible with the most recent ISMRMRD release?

Thanks