### PR TITLE
Fix XSLT file 

### DIFF
--- a/IsmrmrdPhilips.xsl
+++ b/IsmrmrdPhilips.xsl
@@ -64,13 +64,13 @@
         <encodedSpace>
           <matrixSize>
             <x>
-              <xsl:value-of select="philips/recon_resolutions/value[1] * $readoutOversampling"/>
+              <xsl:value-of select="round(philips/recon_resolutions/value[1] * $readoutOversampling)"/>
             </x>
             <y>
-              <xsl:value-of select="philips/recon_resolutions/value[2] * $phaseOversampling"/>
+              <xsl:value-of select="round(philips/recon_resolutions/value[2] * $phaseOversampling)"/>
             </y>
             <z>
-              <xsl:value-of select="philips/recon_resolutions/value[3] * $sliceOversampling"/>
+              <xsl:value-of select="round(philips/recon_resolutions/value[3] * $sliceOversampling)"/>
             </z>
           </matrixSize>
 

--- a/IsmrmrdPhilips.xsl
+++ b/IsmrmrdPhilips.xsl
@@ -182,7 +182,9 @@
 
       <sequenceParameters>
         <xsl:for-each select="philips/repetition_times/value">
-          <TR>ETH</TR>
+          <TR>
+            <xsl:value-of select="." />
+          </TR>
         </xsl:for-each>
         <xsl:for-each select="philips/echo_times/value">
           <TE>

--- a/IsmrmrdPhilips.xsl
+++ b/IsmrmrdPhilips.xsl
@@ -33,9 +33,9 @@
         <measurementID>
           <xsl:value-of select="concat($patientID, $strSeperator, $studyID, $strSeperator, string(siemens/HEADER/MeasUID))"/>
         </measurementID>
-	<patientPosition>HFS</patientPosition> <!-- TODO: must be calculated somehow -->
+        <patientPosition>HFS</patientPosition> <!-- TODO: must be calculated somehow -->
         <protocolName>
-		<xsl:for-each select="philips/scan_name/value"><xsl:value-of select="." /><xsl:choose><xsl:when test="position() != last()"><xsl:text> </xsl:text></xsl:when></xsl:choose></xsl:for-each>
+          <xsl:for-each select="philips/scan_name/value"><xsl:value-of select="." /><xsl:choose><xsl:when test="position() != last()"><xsl:text> </xsl:text></xsl:when></xsl:choose></xsl:for-each>
         </protocolName>
       </measurementInformation>
 
@@ -45,14 +45,14 @@
         <receiverChannels>
           <xsl:value-of select="philips/nr_measured_channels/value" />
         </receiverChannels>
-	
-	<!-- Coil Labels -->
-	<xsl:for-each select="philips/channel_names">
-	  <coilLabel>
-	    <coilNumber><xsl:value-of select="./@idx1"/></coilNumber>
-	    <coilName><xsl:value-of select="./value"/></coilName>
-	  </coilLabel>
-	</xsl:for-each>
+
+        <!-- Coil Labels -->
+        <xsl:for-each select="philips/channel_names">
+          <coilLabel>
+            <coilNumber><xsl:value-of select="./@idx1"/></coilNumber>
+            <coilName><xsl:value-of select="./value"/></coilName>
+          </coilLabel>
+        </xsl:for-each>
       </acquisitionSystemInformation>
 
       <experimentalConditions>
@@ -83,7 +83,7 @@
             </y>
             <z>
               <xsl:value-of select="philips/voxel_sizes/value[3] * philips/recon_resolutions/value[3] * $sliceOversampling"/>
-            </z>		  
+            </z>
           </fieldOfView_mm>
         </encodedSpace>
         <reconSpace>
@@ -108,26 +108,26 @@
             </y>
             <z>
               <xsl:value-of select="philips/voxel_sizes/value[3] * philips/recon_resolutions/value[3]"/>
-            </z>		  
+            </z>
           </fieldOfView_mm>
         </reconSpace>
         <encodingLimits>
           <kspace_encoding_step_1>
             <minimum>0</minimum>
             <maximum>
-	      <xsl:value-of select="philips/max_encoding_numbers/value[2]-philips/min_encoding_numbers/value[2]"/>
+              <xsl:value-of select="philips/max_encoding_numbers/value[2]-philips/min_encoding_numbers/value[2]"/>
             </maximum>
             <center>
-	      <xsl:value-of select="floor((philips/max_encoding_numbers/value[2]-philips/min_encoding_numbers/value[2]) div 2)"/>
+              <xsl:value-of select="floor((philips/max_encoding_numbers/value[2]-philips/min_encoding_numbers/value[2]) div 2)"/>
             </center>
           </kspace_encoding_step_1>
           <kspace_encoding_step_2>
             <minimum>0</minimum>
             <maximum>
-	      <xsl:value-of select="philips/max_encoding_numbers/value[3]-philips/min_encoding_numbers/value[3]"/>
+              <xsl:value-of select="philips/max_encoding_numbers/value[3]-philips/min_encoding_numbers/value[3]"/>
             </maximum>
             <center>
-	      <xsl:value-of select="floor((philips/max_encoding_numbers/value[3]-philips/min_encoding_numbers/value[3]) div 2)"/>
+              <xsl:value-of select="floor((philips/max_encoding_numbers/value[3]-philips/min_encoding_numbers/value[3]) div 2)"/>
             </center>
           </kspace_encoding_step_2>
           <slice>
@@ -153,11 +153,11 @@
           </phase>
           <repetition>
             <minimum>0</minimum>
-	    <maximum>
-              <xsl:value-of select="philips/nr_dynamic_scans/value - 1"/>
-	    </maximum>
+            <maximum>
+                    <xsl:value-of select="philips/nr_dynamic_scans/value - 1"/>
+            </maximum>
             <center>0</center>
-	  </repetition>
+          </repetition>
           <segment>
             <minimum>0</minimum>
             <maximum>0</maximum>
@@ -165,39 +165,39 @@
           </segment>
           <contrast>
             <minimum>0</minimum>
-	    <maximum>
+            <maximum>
               <xsl:value-of select="philips/nr_echoes/value - 1"/>
-	    </maximum>
+            </maximum>
             <center>0</center>
           </contrast>
           <average>
             <minimum>0</minimum>
-	    <maximum>
-              <xsl:value-of select="philips/nr_measurements/value - 1"/>
-	    </maximum>
+            <maximum>
+                    <xsl:value-of select="philips/nr_measurements/value - 1"/>
+            </maximum>
             <center>0</center>
           </average>
         </encodingLimits>
       </encoding>
 
       <sequenceParameters>
-	<xsl:for-each select="philips/repetition_times/value">
-	  <TR>ETH</TR>
+        <xsl:for-each select="philips/repetition_times/value">
+          <TR>ETH</TR>
         </xsl:for-each>
-	<xsl:for-each select="philips/echo_times/value">
-	  <TE>
+        <xsl:for-each select="philips/echo_times/value">
+          <TE>
             <xsl:value-of select="." />
-	  </TE>
+          </TE>
         </xsl:for-each>
-	<xsl:for-each select="philips/inversion_delays/value">
-	  <TI>
+        <xsl:for-each select="philips/inversion_delays/value">
+          <TI>
             <xsl:value-of select="." />
-	  </TI>
+          </TI>
         </xsl:for-each>
-	<xsl:for-each select="philips/flip_angles/value">
-	  <flipAngle_deg>
+        <xsl:for-each select="philips/flip_angles/value">
+          <flipAngle_deg>
             <xsl:value-of select="." />
-	  </flipAngle_deg>
+          </flipAngle_deg>
         </xsl:for-each>
       </sequenceParameters>
     </ismrmrdHeader>


### PR DESCRIPTION
This fixes #4 by rounding the encodedSpace matrixSize variables. The problem was caused by the sliceOversampling variable, which (I'm guessing here) is originally calculated by dividing the encoded size by the reconstructed size and then truncated to few decimal points (4 in my test files, I don't know if this is the general case), so that when the matrixSize is recalculated here it does not yield an integer but a very close floating point value which in turn is rejected by the header xml parser that expects an [unsigned short](https://github.com/ismrmrd/ismrmrd/blob/master/schema/ismrmrd.xsd#L130).

It also (kind of) fixes #8 but I am not sure why it was changed in the first place in [here](https://github.com/ismrmrd/philips_to_ismrmrd/commit/1ba51ba53274f02dad12e2836f695d95b5a0f274#diff-e51ce7bef84fd1a86d284b61ac55c0d3R185)